### PR TITLE
Editable terminal and Python 2.7 compatibility

### DIFF
--- a/launcher/__main__.py
+++ b/launcher/__main__.py
@@ -48,6 +48,7 @@ def cli():
         os.getenv(dep) for dep in dependencies
     ] + sys.path
 
+    print("Using Python @ '%s'" % sys.executable)
     print("Using core @ '%s'" % os.getenv("AVALON_CORE"))
     print("Using launcher @ '%s'" % os.getenv("AVALON_LAUNCHER"))
     print("Using root @ '%s'" % kwargs.root)

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -7,7 +7,6 @@ import shutil
 import getpass
 import traceback
 import contextlib
-import StringIO
 
 from PyQt5 import QtCore
 
@@ -15,12 +14,14 @@ from avalon import io, schema
 from avalon.vendor import toml, six
 from . import lib, model, terminal
 
+PY2 = sys.version_info[0] == 2
+
 
 @contextlib.contextmanager
 def stdout():
     old = sys.stdout
 
-    stdout = StringIO.StringIO()
+    stdout = six.StringIO()
     sys.stdout = stdout
 
     try:
@@ -187,9 +188,12 @@ class Controller(QtCore.QObject):
                 environment[key] = os.pathsep.join(value)
 
             elif isinstance(value, six.string_types):
-                # Protect against unicode in the environment
-                encoding = sys.getfilesystemencoding()
-                environment[key] = value.encode(encoding)
+                if PY2:
+                    # Protect against unicode in the environment
+                    encoding = sys.getfilesystemencoding()
+                    environment[key] = value.encode(encoding)
+                else:
+                    environment[key] = value
 
             else:
                 terminal.log(

--- a/launcher/lib.py
+++ b/launcher/lib.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import json
 import subprocess
 
 from avalon.vendor import six
@@ -142,16 +141,20 @@ def launch(executable, args=None, environment=None):
 
     CREATE_NO_WINDOW = 0x08000000
     IS_WIN32 = sys.platform == "win32"
+    PY2 = sys.version_info[0] == 2
 
     abspath = executable
 
-    # Protect against unicode, and other unsupported
-    # types amongst environment variables
-    enc = sys.getfilesystemencoding()
-    env = {
-        k.encode(enc): v.encode(enc)
-        for k, v in (environment or os.environ).items()
-    }
+    env = (environment or os.environment)
+
+    if PY2:
+        # Protect against unicode, and other unsupported
+        # types amongst environment variables
+        enc = sys.getfilesystemencoding()
+        env = {
+            k.encode(enc): v.encode(enc)
+            for k, v in (environment or os.environ).items()
+        }
 
     kwargs = dict(
         args=[abspath] + args or list(),

--- a/launcher/res/qml/main.qml
+++ b/launcher/res/qml/main.qml
@@ -10,6 +10,8 @@ ApplicationWindow {
     visible: true
     width: 500
     height: 500
+    minimumHeight: 300
+    minimumWidth: 300
     color: "#444"
 
     header: ColumnLayout {
@@ -81,6 +83,8 @@ ApplicationWindow {
                     implicitHeight: parent.height
                     implicitWidth: parent.height
                     Layout.alignment: Qt.AlignRight
+
+                    onClicked: terminalTextField.focus = true
                 }
 
                 /** Toggle Attribute Editor on/off
@@ -161,7 +165,7 @@ ApplicationWindow {
     Rectangle {
         id: terminalContainer
 
-        height: terminalButton.checked ? 200 : 0
+        height: terminalButton.checked ? window.height / 2 : 0
 
         anchors {
             left: parent.left
@@ -178,16 +182,49 @@ ApplicationWindow {
         clip: true
         visible: height > 0
 
-        ListView {
-            id: terminalView
+        ColumnLayout {
             anchors.fill: parent
-            model: terminal
-            delegate: Text {
-                text: line
-                color: "#eee"
-                width: ListView.view.width
+
+            ListView {
+                id: terminalView
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.margins: 3
+                ScrollBar.vertical: ScrollBar { }
+                ScrollBar.horizontal: ScrollBar { }
+
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+
+                model: terminal
+                delegate: Text {
+                    text: line
+                    font.family: "consolas"
+                    font.pointSize: 9
+                    color: "#eee"
+                    wrapMode: Text.WordWrap
+                    width: ListView.view.width
+                }
+            }
+
+            TextField {
+                id: terminalTextField
+                Layout.fillWidth: true
+                background: Item {}
+                selectionColor: "#555"
+                height: contentHeight + 2
+                color: "white"
+                cursorVisible: true
+                font.family: "consolas"
+                font.pointSize: 9
+
+                onAccepted: {
+                    controller.command(text)
+                    clear()
+                }
             }
         }
+
     }
 
     /** Respond to changes from controller


### PR DESCRIPTION
Python 2.7 struggled with unicode in the resulting environment from the Launcher, I've repaired this by encoding unicode into the system default. On Python 3, this won't make any difference.

In order to figure this one out, I implemented a basic REPL into the existing terminal.

![untitled project](https://user-images.githubusercontent.com/2152766/27922757-049b8e44-6274-11e7-9c0b-812fb4fc338a.gif)
