### PR TITLE
Avalon Launcher browsing steps 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.bat
 *.pyc
 __pycache__/
+
+.idea/

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -372,23 +372,35 @@ class Controller(QtCore.QObject):
         handler(index)
         self.navigated.emit()
 
-    @Slot()
-    def pop(self):
-        self._frames.pop()
-        self._model.pop()
+    @Slot(int)
+    def pop(self, index=None):
 
-        if not self.breadcrumbs:
-            self.popped.emit()
-            self.navigated.emit()
-            return self.init()
-
-        try:
-            self.breadcrumbs.pop()
-        except IndexError:
-            pass
+        if index is None:
+            # Regular pop behavior
+            steps = 1
+        elif index < 0:
+            # Refresh; go beyond first index
+            steps = len(self.breadcrumbs) + 1
         else:
-            self.popped.emit()
-            self.navigated.emit()
+            # Go to index
+            steps = len(self.breadcrumbs) - index - 1
+
+        for i in range(steps):
+            self._frames.pop()
+            self._model.pop()
+
+            if not self.breadcrumbs:
+                self.popped.emit()
+                self.navigated.emit()
+                return self.init()
+
+            try:
+                self.breadcrumbs.pop()
+            except IndexError:
+                pass
+            else:
+                self.popped.emit()
+                self.navigated.emit()
 
     def init(self):
         terminal.log("initialising..")

--- a/launcher/res/qml/Breadcrumbs.qml
+++ b/launcher/res/qml/Breadcrumbs.qml
@@ -12,15 +12,13 @@ Item {
 
         ToolButton {
             contentItem: AwesomeIcon {
-                name: "refresh"
+                name: "home"
                 size: 12
             }
 
-            visible: repeater.count == 0
-
             height: parent.height
             width: parent.height
-            onClicked: controller.pop()
+            onClicked: controller.pop(-1)
         }
 
         Repeater {
@@ -41,7 +39,7 @@ Item {
 
                 height: parent.height
                 font.pixelSize: 10
-                onClicked: controller.pop()
+                onClicked: controller.pop(index)
             }
         }
     }


### PR DESCRIPTION
Instead of going one step back per click, the Launcher takes the needed amount of steps back with one click to go to the clicked step.
Similar behavior to Windows explorer, see example below.

![image](https://user-images.githubusercontent.com/26920875/32653605-b40838c6-c608-11e7-8dbd-108092b88368.png)

### Other changes
* Changed refresh icon to home icon
* Home icon stays visible while browsing (needed for technical purposes)
* `control.pop` now supports index as argument