### PR TITLE
Hotfix for icons

### DIFF
--- a/launcher/app.py
+++ b/launcher/app.py
@@ -6,7 +6,7 @@ import sys
 
 # Dependencies
 from avalon import io
-import avalon.vendor.qtawesome as qta
+# import avalon.vendor.qtawesome as qta
 from PyQt5 import QtCore, QtGui, QtQml, QtWidgets, QtQuick
 
 # Local libraries
@@ -71,15 +71,16 @@ class Application(QtWidgets.QApplication):
 
         # Build the right-mouse context menu for the tray icon
         menu = QtWidgets.QMenu()
-        icon_color = "#509eff"   # launcher icon color
+        # icon_color = "#509eff"   # launcher icon color
 
         def window_show():
             self.window.show()
             self.window.raise_()
             self.window.requestActivate()
 
-        icon = qta.icon("fa.eye", color=icon_color)
-        show = QtWidgets.QAction(icon, "Show", self)
+        # Disabled icon due to mismatching font versions
+        # icon = qta.icon("fa.eye", color=icon_color)
+        show = QtWidgets.QAction("Show", self)
         show.triggered.connect(window_show)
         menu.addAction(show)
 
@@ -92,8 +93,9 @@ class Application(QtWidgets.QApplication):
 
             self.quit()
 
-        icon = qta.icon("fa.close", color=icon_color)
-        quit = QtWidgets.QAction(icon, "Quit", self)
+        # Disabled icon due to mismatching font versions
+        # icon = qta.icon("fa.close", color=icon_color)
+        quit = QtWidgets.QAction("Quit", self)
         quit.triggered.connect(on_quit)
         menu.addAction(quit)
         tray.setContextMenu(menu)

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -6,7 +6,6 @@ import sys
 
 # Dependencies
 from avalon import io
-# import avalon.vendor.qtawesome as qta
 from PyQt5 import QtCore, QtGui, QtQml, QtWidgets, QtQuick
 
 # Local libraries
@@ -15,6 +14,9 @@ from . import control, terminal, lib
 QML_IMPORT_DIR = lib.resource("qml")
 APP_PATH = lib.resource("qml", "main.qml")
 ICON_PATH = lib.resource("icon", "main.png")
+
+# TODO: Re-implement icons of tray menu after resolving #323
+# Issue 323: https://github.com/getavalon/core/issues/323
 
 
 class Application(QtWidgets.QApplication):
@@ -71,15 +73,12 @@ class Application(QtWidgets.QApplication):
 
         # Build the right-mouse context menu for the tray icon
         menu = QtWidgets.QMenu()
-        # icon_color = "#509eff"   # launcher icon color
 
         def window_show():
             self.window.show()
             self.window.raise_()
             self.window.requestActivate()
 
-        # Disabled icon due to mismatching font versions
-        # icon = qta.icon("fa.eye", color=icon_color)
         show = QtWidgets.QAction("Show", self)
         show.triggered.connect(window_show)
         menu.addAction(show)
@@ -93,8 +92,6 @@ class Application(QtWidgets.QApplication):
 
             self.quit()
 
-        # Disabled icon due to mismatching font versions
-        # icon = qta.icon("fa.close", color=icon_color)
         quit = QtWidgets.QAction("Quit", self)
         quit.triggered.connect(on_quit)
         menu.addAction(quit)


### PR DESCRIPTION
This resolves any clashes with Font Awesome from core and launcher which can result in unexpected icons.

* Removed icons from tray icon menu and the `qtawesome` import from `core`
* Added todo

See this [issue](https://github.com/getavalon/core/issues/323) for more details