### PR TITLE
Clean session steps

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -5,6 +5,16 @@ self = sys.modules[__name__]
 self._is_installed = False
 
 
+_SESSION_STEPS = (
+    "AVALON_PROJECT",
+    "AVALON_SILO",
+    "AVALON_ASSET",
+    "AVALON_TASK",
+    "AVALON_APP",
+)
+_PLACEHOLDER = "placeholder"
+
+
 def install():
     """Register actions"""
 

--- a/launcher/__main__.py
+++ b/launcher/__main__.py
@@ -5,6 +5,8 @@ import sys
 import argparse
 import importlib
 
+from . import _SESSION_STEPS, _PLACEHOLDER
+
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
 
@@ -75,12 +77,8 @@ def cli():
 
     # Fulfill schema, and expect the application
     # to fill it in in due course.
-    for placeholder in ("AVALON_PROJECT",
-                        "AVALON_ASSET",
-                        "AVALON_SILO",
-                        "AVALON_TASK",
-                        "AVALON_APP",):
-        os.environ[placeholder] = "placeholder"
+    for step in _SESSION_STEPS:
+        os.environ[step] = _PLACEHOLDER
 
     print("Using Python @ '%s'" % sys.executable)
     print("Using root @ '%s'" % kwargs.root)

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -373,8 +373,8 @@ class Controller(QtCore.QObject):
             # If the task is in the project configuration than get the settings
             # from the project config to also support its icons, etc.
             task_config = {task['name']: task for task in project_tasks}
-            tasks = [task_config.get(name, {"name": name})
-                     for name in asset_tasks]
+            tasks = [task_config.get(task_name, {"name": task_name})
+                     for task_name in asset_tasks]
         else:
             # if no `asset.data['tasks']` override then
             # get the tasks from project configuration

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -9,6 +9,7 @@ from PyQt5 import QtCore
 from avalon import api, io
 from avalon.vendor import six
 from . import lib, model, terminal
+from . import _SESSION_STEPS, _PLACEHOLDER
 
 PY2 = sys.version_info[0] == 2
 
@@ -234,6 +235,10 @@ class Controller(QtCore.QObject):
             else:
                 self.popped.emit()
                 self.navigated.emit()
+
+            # Revert to placeholder
+            step = _SESSION_STEPS[len(self.breadcrumbs)]
+            api.Session[step] = _PLACEHOLDER
 
     def init(self):
         terminal.log("initialising..")


### PR DESCRIPTION
### Problem

While jumping session pages (steps), for example, from *App* page back to *Silo* page, I found the 
entries like `AVALON_TASK`, `AVALON_ASSET` in `api.Session` still holds the previous values.

Here I made an action to print out session steps and see what's happening.

![clean_before](https://user-images.githubusercontent.com/3357009/55293690-a4fece00-542b-11e9-8f31-eded5d9cdbab.gif)

This cause a problem for one of my action which was assembling session steps to do stuff and may lead to unexpected result if those steps not update correctly.

### Fix

Commit 21da567 did not fix the problem, I thought it might related since my IDE shows a warning, but it didn't.

The commit f0835ae fixed this.

![clean_after](https://user-images.githubusercontent.com/3357009/55293691-a62ffb00-542b-11e9-81ad-bfea0da299ab.gif)
