### PR TITLE
Update avalon core module name for upcoming new era

### DIFF
--- a/launcher/actions.py
+++ b/launcher/actions.py
@@ -30,7 +30,7 @@ class LoaderAction(api.Action):
 
     def process(self, session, **kwargs):
         return lib.launch(executable="python",
-                          args=["-u", "-m", "avalon.tools.cbloader",
+                          args=["-u", "-m", "avalon.tools.loader",
                                 session['AVALON_PROJECT']])
 
 


### PR DESCRIPTION
Fix `loader` action, for PR in getavalon/core#388