### PR TITLE
Available for newer PyQt

### DIFF
--- a/launcher/res/qml/Breadcrumbs.qml
+++ b/launcher/res/qml/Breadcrumbs.qml
@@ -15,7 +15,7 @@ Item {
                 name: "home"
                 size: 18
             }
-
+            background: Item { }  // Hide background
             height: parent.height
             width: parent.height
             onClicked: controller.pop(-1)

--- a/launcher/res/qml/MyButton.qml
+++ b/launcher/res/qml/MyButton.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls 2.0
 Button {
     id: control
 
-    property var icon: "adjust"
+    property var custom_icon: "adjust"
 
 	background: Rectangle {
         color: "transparent"
@@ -13,7 +13,7 @@ Button {
 
     AwesomeIcon {
         anchors.fill: parent
-        name: control.icon
+        name: control.custom_icon
         opacity: !control.checkable ? 1.0 : control.checked ? 1.0 : 0.4
     }
 }

--- a/launcher/res/qml/main.qml
+++ b/launcher/res/qml/main.qml
@@ -87,7 +87,7 @@ ApplicationWindow {
                     id: launchExplorerButton
                     implicitWidth: parent.height
                     implicitHeight: parent.height
-                    icon: "folder-open"
+                    custom_icon: "folder-open"
                     Layout.alignment: Qt.AlignLeft
 
                     onClicked: controller.launch_explorer()
@@ -99,7 +99,7 @@ ApplicationWindow {
                  */
                 MyButton {
                     id: terminalButton
-                    icon: "terminal"
+                    custom_icon: "terminal"
                     checkable: true
                     implicitHeight: parent.height
                     implicitWidth: parent.height
@@ -115,7 +115,7 @@ ApplicationWindow {
                     implicitWidth: parent.height
                     implicitHeight: parent.height
                     checkable: true
-                    icon: "adjust"
+                    custom_icon: "adjust"
                     Layout.alignment: Qt.AlignRight
                 }
             }

--- a/launcher/version.py
+++ b/launcher/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
- renaming of `icon` variable makes possible to run launcher with newer PyQt
- PyQt is printing warnings for `AwesomeIcon` with recommending but it's not crashing