### PR TITLE
Fix asset task view

### DIFF
--- a/launcher/control.py
+++ b/launcher/control.py
@@ -374,6 +374,7 @@ class Controller(QtCore.QObject):
 
         # Get the tasks assigned to the asset
         asset_tasks = asset.get("data", {}).get("tasks", None)
+        tasks = []
         if asset_tasks is not None:
             # If the task is in the project configuration then get the settings
             # from the project config to also support its icons, etc.

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -375,15 +375,11 @@ class Controller(QtCore.QObject):
         # Get the tasks assigned to the asset
         asset_tasks = asset.get("data", {}).get("tasks", None)
         if asset_tasks is not None:
-            # If the task is in the project configuration than get the settings
+            # If the task is in the project configuration then get the settings
             # from the project config to also support its icons, etc.
             task_config = {task['name']: task for task in project_tasks}
             tasks = [task_config.get(task_name, {"name": task_name})
                      for task_name in asset_tasks]
-        else:
-            # if no `asset.data['tasks']` override then
-            # get the tasks from project configuration
-            tasks = project_tasks
 
         # If task has no icon use fallback icon
         for task in tasks:

--- a/launcher/control.py
+++ b/launcher/control.py
@@ -3,6 +3,7 @@ import sys
 import copy
 import traceback
 import contextlib
+from distutils.util import strtobool
 
 from PyQt5 import QtCore
 
@@ -374,13 +375,22 @@ class Controller(QtCore.QObject):
 
         # Get the tasks assigned to the asset
         asset_tasks = asset.get("data", {}).get("tasks", None)
-        tasks = []
         if asset_tasks is not None:
             # If the task is in the project configuration then get the settings
             # from the project config to also support its icons, etc.
             task_config = {task['name']: task for task in project_tasks}
             tasks = [task_config.get(task_name, {"name": task_name})
                      for task_name in asset_tasks]
+        else:
+            if strtobool(api.Session.get("AVALON_EARLY_ADOPTER", "False")):
+                # if no `asset.data['tasks']` override and the early adopter
+                # flag is set, don't show any tasks
+                tasks = []
+            else:
+                # if no `asset.data['tasks']` override and the early adopter
+                # flag is not set, then get the tasks from project
+                # configuration
+                tasks = project_tasks
 
         # If task has no icon use fallback icon
         for task in tasks:

--- a/launcher/res/qml/MyButton.qml
+++ b/launcher/res/qml/MyButton.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls 2.0
 Button {
     id: control
 
-    property var icon: "adjust"
+    property var avalonicon: "adjust"
 
 	background: Rectangle {
         color: "transparent"
@@ -13,7 +13,7 @@ Button {
 
     AwesomeIcon {
         anchors.fill: parent
-        name: control.icon
+        name: control.avalonicon
         opacity: !control.checkable ? 1.0 : control.checked ? 1.0 : 0.4
     }
 }

--- a/launcher/res/qml/main.qml
+++ b/launcher/res/qml/main.qml
@@ -87,7 +87,7 @@ ApplicationWindow {
                     id: launchExplorerButton
                     implicitWidth: parent.height
                     implicitHeight: parent.height
-                    icon: "folder-open"
+                    avalonicon: "folder-open"
                     Layout.alignment: Qt.AlignLeft
 
                     onClicked: controller.launch_explorer()
@@ -99,7 +99,7 @@ ApplicationWindow {
                  */
                 MyButton {
                     id: terminalButton
-                    icon: "terminal"
+                    avalonicon: "terminal"
                     checkable: true
                     implicitHeight: parent.height
                     implicitWidth: parent.height
@@ -115,7 +115,7 @@ ApplicationWindow {
                     implicitWidth: parent.height
                     implicitHeight: parent.height
                     checkable: true
-                    icon: "adjust"
+                    avalonicon: "adjust"
                     Layout.alignment: Qt.AlignRight
                 }
             }


### PR DESCRIPTION
As discussed on [Gitter](https://gitter.im/getavalon/Lobby?at=5d3ab0c7a0a9760d34a0dd49) this makes only specific asset tasks show up in the Launcher.
This makes it consistent with the Project Launcher changes in [this PR](https://github.com/getavalon/core/pull/403).